### PR TITLE
ioping: sleep before the first iteration

### DIFF
--- a/ioping.c
+++ b/ioping.c
@@ -1181,6 +1181,9 @@ skip_preparation:
 	period_deadline = time_now + period_time;
 
 	while (!exiting) {
+		if (interval)
+			nanosleep(&interval_ts, NULL);
+
 		request++;
 		part_request++;
 
@@ -1292,9 +1295,6 @@ skip_preparation:
 
 		if (deadline && time_next >= deadline)
 			break;
-
-		if (interval)
-			nanosleep(&interval_ts, NULL);
 	}
 
 	time_sum += part_sum;


### PR DESCRIPTION
Hi Kostya!

I have a weird situation, when the first ping is 10 times faster then
others:

 ./ioping -D -WWW -s 4K -c 10 /dev/mmcblk1p4
4 KiB to /dev/mmcblk1p4 (block device 2.00 GiB): request=1 time=3.24 ms
4 KiB to /dev/mmcblk1p4 (block device 2.00 GiB): request=2 time=42.2 ms
4 KiB to /dev/mmcblk1p4 (block device 2.00 GiB): request=3 time=43.5 ms

eMMC card tends to fell asleep, which increases the latency
dramatically. Looks like fdatasync executed right before the while loop
keeps the eMMC awake.

Just move the sleep to the beginning of the loop, so all latencies will
include the waking up time.