### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
-os:
-  - linux
-  - osx
-
+matrix:
+   include:
+      - os: linux
+        arch: amd64
+      - os: linux
+        arch: ppc64le
+      - os: osx
+        arch: amd64
 script:
   - make
   - make test


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/ioping/builds/191023067 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!