### PR TITLE
allow io to fail and count failed read and write operations

### DIFF
--- a/ioping.c
+++ b/ioping.c
@@ -1922,6 +1922,16 @@ skip_preparation:
 		print_int(total.too_slow);
 		printf(" too slow, ");
 	}
+	if (total.read_fail) {
+		print_int(total.read_fail);
+		printf(" read failed, ");
+	}
+	if (total.write_fail) {
+		print_int(total.write_fail);
+		printf(" write failed, ");
+	}
+	
+
 	printf("generated ");
 	print_int(total.count);
 	printf(" requests in ");


### PR DESCRIPTION
Hi,
as I have to test the network between a customers hypervisor and the storage system, I implemented a very basic support for failed requests. 
Would be great to have this merged.
Br
Willi